### PR TITLE
Document per-teacher configuration steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,23 @@ This project provides a single-page kiosk and admin dashboard for tracking class
 
 1. Open `index.html` in a modern browser. The page includes all styling and scripts required to run the kiosk.
 2. Configure your Firebase project credentials by updating the `window.__firebase_config` object near the top of the file.
-3. (Optional) Set a consistent `window.__app_id` value for all kiosks you deploy so that they share data within the same Firestore namespace.
+3. Set a consistent `window.__app_id` value for every kiosk that should share data within the same Firestore namespace.
 4. Upload class rosters and (optionally) schedules from the admin panel to begin tracking attendance.
+
+## Multi-teacher setup
+
+To let multiple teachers use their own rosters, group configurations, and seating exceptions, give each teacher an isolated Firestore namespace and a unique layout document.
+
+1. **Clone and customize `index.html` for each teacher.** Create a copy of the file (or deploy per-teacher versions) so you can give them individual settings.
+2. **Assign a unique `window.__app_id`.** In each teacher's copy, set `window.__app_id` to a unique value (for example, `"ms-salas-periods"`, `"mr-lee-periods"`, etc.). Firestore stores all rosters, seating exceptions, and attendance data under that ID, so distinct values keep their data completely separate.
+3. **Give each teacher a `window.__teacher_id`.** Set a distinct value such as their email prefix or initials. Group layout preferences (max group count, seats per group, which groups count as front row, etc.) are stored per teacher ID, so this keeps layout changes from colliding.
+4. **Allow their Google account to sign in.** Update the `window.__teacher_allowlist` / `window.__teacher_emails` array (or `window.__teacher_domain`) so their Google login is authorized to open the Teacher Admin panel.
+5. **Distribute the personalized link.** Share the customized `index.html` (or its hosted URL) with the teacher. When they sign in with their allowed Google account they can upload their own roster, set seating exceptions, configure group sizes/front-row tags, and manage attendance without affecting anyone else.
+
+> **Note:** If two teachers intentionally need to share the same rosters and exceptions, give them the *same* `window.__app_id` and (optionally) distinct `window.__teacher_id` values. Only the app ID determines who sees which rosters/exceptions; the teacher ID controls layout preferences.
 
 ## Development Notes
 
 - The application relies on the Firebase web SDK v10 (modular) for auth and Firestore access.
 - Tailwind CSS is loaded from a CDN; no additional build steps are required.
 - All business logic, UI updates, and automated tests are contained within `index.html` for ease of deployment.
-


### PR DESCRIPTION
## Summary
- expand the README with detailed guidance for configuring kiosks for multiple teachers
- document how to isolate rosters and exceptions by assigning unique `window.__app_id` values
- explain per-teacher group layout settings and access controls via `window.__teacher_id` and allow lists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf33e69e0483298a96ac98ab8a02d7