### PR TITLE
Preserve teacher login across sessions

### DIFF
--- a/index.html
+++ b/index.html
@@ -835,8 +835,20 @@ function setTeacherLoggedOut(message='Teacher sign-in required for admin tools.'
 
 async function ensureAnonymousAuth(){
   if(!auth || reauthingAnonymous) return;
-  const current = auth.currentUser;
+  try{
+    if(typeof auth.authStateReady === 'function'){
+      await auth.authStateReady();
+    }
+  }catch(err){
+    console.warn('[auth] authStateReady() failed', err);
+  }
+  let current = auth.currentUser;
   if(current) return;
+  if(typeof auth.authStateReady !== 'function'){
+    await new Promise(resolve=>setTimeout(resolve, 250));
+    current = auth.currentUser;
+    if(current) return;
+  }
   reauthingAnonymous = true;
   try{
     await signInAnonymously(auth);


### PR DESCRIPTION
## Summary
- wait for Firebase to finish restoring any persisted user before attempting anonymous sign-in
- add a short fallback delay when authStateReady() is unavailable so existing sessions are not overwritten

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf6cc54018832993dfcd69e6232f09